### PR TITLE
fix:remove the duplicate separator and use File.separator instead

### DIFF
--- a/open-exp-code/open-exp-classloader-container-impl/src/main/java/cn/think/in/java/open/exp/classloader/impl/PluginMetaServiceImpl.java
+++ b/open-exp-code/open-exp-classloader-container-impl/src/main/java/cn/think/in/java/open/exp/classloader/impl/PluginMetaServiceImpl.java
@@ -72,7 +72,7 @@ public class PluginMetaServiceImpl implements PluginMetaService {
         }
         Map<String, String> mapping = MetaConfigReader.getMapping(file);
 
-        String dir = pluginMetaConfig.getWorkDir() + "/" + meta.getPluginId();
+        String dir = pluginMetaConfig.getWorkDir() + File.separator + meta.getPluginId();
         if (new File(dir).exists()) {
             log.warn("---->>>>> 插件目录已经存在, 删除 = {}", dir);
             if (Boolean.parseBoolean(pluginMetaConfig.getAutoDelete())) {

--- a/open-exp-code/open-exp-classloader-container/src/main/java/cn/think/in/java/open/exp/classloader/PluginMetaConfig.java
+++ b/open-exp-code/open-exp-classloader-container/src/main/java/cn/think/in/java/open/exp/classloader/PluginMetaConfig.java
@@ -11,7 +11,7 @@ import lombok.Data;
 @Data
 public class PluginMetaConfig {
 
-    String workDir = "exp-tmp-dir/";
+    String workDir = "exp-tmp-dir";
     String autoDelete = "true";
 
 


### PR DESCRIPTION
**Description**
    the workDir has file separator. but PluginMetaServiceImpl#install also added "/", so we should remove the duplicate and use File.separator instead.


**Checklist**

- [x]  I have explained the need for this PR and the problem it solves
- [ ]  I have explained the changes or the new features added to this PR
- [ ]  I have added tests corresponding to this change
 - [ ] I have updated the documentation to reflect this change
- [ ]  I have verified that this change is backward compatible 