### PR TITLE
fix:PluginLifeCycleHook postInit() before at addHook() and reduce loop

### DIFF
--- a/example/example-plugin-a-v1/src/main/java/cn/think/in/java/open/exp/example/a/UserPluginLifeCycleHook.java
+++ b/example/example-plugin-a-v1/src/main/java/cn/think/in/java/open/exp/example/a/UserPluginLifeCycleHook.java
@@ -1,0 +1,25 @@
+package cn.think.in.java.open.exp.example.a;
+
+import cn.think.in.java.open.exp.client.ObjectStore;
+import cn.think.in.java.open.exp.client.PluginLifeCycleHook;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Supplier;
+
+/**
+ * @Description PluginLifeCycleHook example
+ * @Author jujiale
+ * @Date 2023/12/24
+ */
+@Component
+public class UserPluginLifeCycleHook implements PluginLifeCycleHook {
+    @Override
+    public void postInit(ObjectStore objectStore, Class<?> clazz, Supplier<Object> bean, String beanName) {
+        System.out.println("example-plugin-a-v1#UserPluginLifeCycleHook#postInit invoked...");
+    }
+
+    @Override
+    public void postDestroy(ObjectStore objectStore, Class<?> aClass, String beanName) {
+        System.out.println("example-plugin-a-v1#UserPluginLifeCycleHook#postDestroy invoked...");
+    }
+}

--- a/example/example-plugin-a-v1/src/main/resources/extension.properties
+++ b/example/example-plugin-a-v1/src/main/resources/extension.properties
@@ -1,1 +1,2 @@
 cn.think.in.java.open.exp.adapter.springboot2.example.UserService=cn.think.in.java.open.exp.example.a.UserPlugin
+cn.think.in.java.open.exp.client.PluginLifeCycleHook=cn.think.in.java.open.exp.example.a.UserPluginLifeCycleHook

--- a/example/example-plugin-a-v2/src/main/java/cn/think/in/java/open/exp/example/a/UserPluginLifeCycleHook.java
+++ b/example/example-plugin-a-v2/src/main/java/cn/think/in/java/open/exp/example/a/UserPluginLifeCycleHook.java
@@ -1,0 +1,25 @@
+package cn.think.in.java.open.exp.example.a;
+
+import cn.think.in.java.open.exp.client.ObjectStore;
+import cn.think.in.java.open.exp.client.PluginLifeCycleHook;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Supplier;
+
+/**
+ * @Description PluginLifeCycleHook example
+ * @Author jujiale
+ * @Date 2023/12/24
+ */
+@Component
+public class UserPluginLifeCycleHook implements PluginLifeCycleHook {
+    @Override
+    public void postInit(ObjectStore objectStore, Class<?> clazz, Supplier<Object> bean, String beanName) {
+        System.out.println("example-plugin-a-v2#UserPluginLifeCycleHook#postInit invoked...");
+    }
+
+    @Override
+    public void postDestroy(ObjectStore objectStore, Class<?> aClass, String beanName) {
+        System.out.println("example-plugin-a-v2#UserPluginLifeCycleHook#postDestroy invoked...");
+    }
+}

--- a/example/example-plugin-a-v2/src/main/resources/extension.properties
+++ b/example/example-plugin-a-v2/src/main/resources/extension.properties
@@ -1,1 +1,2 @@
 cn.think.in.java.open.exp.adapter.springboot2.example.UserService=cn.think.in.java.open.exp.example.a.UserPlugin
+cn.think.in.java.open.exp.client.PluginLifeCycleHook=cn.think.in.java.open.exp.example.a.UserPluginLifeCycleHook

--- a/example/example-plugin-b-v1/src/main/java/cn/think/in/java/open/exp/example/b/UserPluginLifeCycleHook.java
+++ b/example/example-plugin-b-v1/src/main/java/cn/think/in/java/open/exp/example/b/UserPluginLifeCycleHook.java
@@ -1,0 +1,25 @@
+package cn.think.in.java.open.exp.example.b;
+
+import cn.think.in.java.open.exp.client.ObjectStore;
+import cn.think.in.java.open.exp.client.PluginLifeCycleHook;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Supplier;
+
+/**
+ * @Description PluginLifeCycleHook example
+ * @Author jujiale
+ * @Date 2023/12/24
+ */
+@Component
+public class UserPluginLifeCycleHook implements PluginLifeCycleHook {
+    @Override
+    public void postInit(ObjectStore objectStore, Class<?> clazz, Supplier<Object> bean, String beanName) {
+        System.out.println("example-plugin-b-v1#UserPluginLifeCycleHook#postInit invoked...");
+    }
+
+    @Override
+    public void postDestroy(ObjectStore objectStore, Class<?> aClass, String beanName) {
+        System.out.println("example-plugin-b-v1#UserPluginLifeCycleHook#postDestroy invoked...");
+    }
+}

--- a/example/example-plugin-b-v1/src/main/resources/extension.properties
+++ b/example/example-plugin-b-v1/src/main/resources/extension.properties
@@ -1,2 +1,4 @@
 cn.think.in.java.open.exp.adapter.springboot2.example.UserService=\
   cn.think.in.java.open.exp.example.b.UserPlugin
+cn.think.in.java.open.exp.client.PluginLifeCycleHook=\
+  cn.think.in.java.open.exp.example.b.UserPluginLifeCycleHook

--- a/example/example-plugin-b-v2/src/main/java/cn/think/in/java/open/exp/example/b/UserPluginLifeCycleHook.java
+++ b/example/example-plugin-b-v2/src/main/java/cn/think/in/java/open/exp/example/b/UserPluginLifeCycleHook.java
@@ -1,0 +1,25 @@
+package cn.think.in.java.open.exp.example.b;
+
+import cn.think.in.java.open.exp.client.ObjectStore;
+import cn.think.in.java.open.exp.client.PluginLifeCycleHook;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Supplier;
+
+/**
+ * @Description PluginLifeCycleHook example
+ * @Author jujiale
+ * @Date 2023/12/24
+ */
+@Component
+public class UserPluginLifeCycleHook implements PluginLifeCycleHook {
+    @Override
+    public void postInit(ObjectStore objectStore, Class<?> clazz, Supplier<Object> bean, String beanName) {
+        System.out.println("example-plugin-b-v2#UserPluginLifeCycleHook#postInit invoked...");
+    }
+
+    @Override
+    public void postDestroy(ObjectStore objectStore, Class<?> aClass, String beanName) {
+        System.out.println("example-plugin-b-v2#UserPluginLifeCycleHook#postDestroy invoked...");
+    }
+}

--- a/example/example-plugin-b-v2/src/main/resources/extension.properties
+++ b/example/example-plugin-b-v2/src/main/resources/extension.properties
@@ -1,2 +1,4 @@
 cn.think.in.java.open.exp.adapter.springboot2.example.UserService=\
   cn.think.in.java.open.exp.example.b.UserPlugin
+cn.think.in.java.open.exp.client.PluginLifeCycleHook=\
+  cn.think.in.java.open.exp.example.b.UserPluginLifeCycleHook

--- a/example/example-plugin-b-v3-self/src/main/java/cn/think/in/java/open/exp/example/bv3/UserPluginLifeCycleHook.java
+++ b/example/example-plugin-b-v3-self/src/main/java/cn/think/in/java/open/exp/example/bv3/UserPluginLifeCycleHook.java
@@ -1,0 +1,25 @@
+package cn.think.in.java.open.exp.example.bv3;
+
+import cn.think.in.java.open.exp.client.ObjectStore;
+import cn.think.in.java.open.exp.client.PluginLifeCycleHook;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Supplier;
+
+/**
+ * @Description PluginLifeCycleHook example
+ * @Author jujiale
+ * @Date 2023/12/24
+ */
+@Component
+public class UserPluginLifeCycleHook implements PluginLifeCycleHook {
+    @Override
+    public void postInit(ObjectStore objectStore, Class<?> clazz, Supplier<Object> bean, String beanName) {
+        System.out.println("example-b-v3#UserPluginLifeCycleHook#postInit invoked...");
+    }
+
+    @Override
+    public void postDestroy(ObjectStore objectStore, Class<?> aClass, String beanName) {
+        System.out.println("example-b-v3#UserPluginLifeCycleHook#postDestroy invoked...");
+    }
+}

--- a/example/example-plugin-b-v3-self/src/main/resources/extension.properties
+++ b/example/example-plugin-b-v3-self/src/main/resources/extension.properties
@@ -1,2 +1,4 @@
 cn.think.in.java.open.exp.adapter.springboot2.example.UserService=\
   cn.think.in.java.open.exp.example.bv3.UserPlugin
+cn.think.in.java.open.exp.client.PluginLifeCycleHook=\
+  cn.think.in.java.open.exp.example.bv3.UserPluginLifeCycleHook

--- a/open-exp-code/open-exp-core-impl/src/main/java/cn/think/in/java/open/exp/core/impl/ExpAppContextImpl.java
+++ b/open-exp-code/open-exp-core-impl/src/main/java/cn/think/in/java/open/exp/core/impl/ExpAppContextImpl.java
@@ -48,7 +48,6 @@ public class ExpAppContextImpl implements ExpAppContext {
         List<Class<?>> classes = fat.getScanner().scan();
         objectStore.registerCallback(classes, fat.getPluginId());
         all.add(fat.getPluginId());
-        PluginLifeCycleHookManager.addHook(fat.getPluginId());
         log.info("安装加载插件, 插件 ID = [{}], 配置={}", fat.getPluginId(), fat.getConfigSupportList());
         return fat.conv();
     }

--- a/spring-adapter/open-exp-adapter-springboot-common-starter/src/main/java/open/exp/adapter/springboot/common/starter/ObjectStoreSpringboot.java
+++ b/spring-adapter/open-exp-adapter-springboot-common-starter/src/main/java/open/exp/adapter/springboot/common/starter/ObjectStoreSpringboot.java
@@ -62,6 +62,7 @@ public class ObjectStoreSpringboot implements ObjectStore {
         }
 
         objectScans.forEach(e -> e.registerApis(classes, pluginId));
+        PluginLifeCycleHookManager.addHook(pluginId);
         postInit(pluginId, classes);
         classesCache.put(pluginId, classes);
     }
@@ -126,9 +127,6 @@ public class ObjectStoreSpringboot implements ObjectStore {
             } catch (Exception ignore) {
                 //log.warn(ex.getMessage());
             }
-        }
-        for (Class<?> aClass : classes) {
-            String name = PluginNameBuilder.build(aClass, pluginId);
             PluginLifeCycleHookManager.postInit(this, aClass, () -> beanFactory.getBean(name), name);
         }
     }


### PR DESCRIPTION
**Description** 

https://github.com/stateIs0/exp/blob/7cdba8341afd106a5068c5e54043b76dbc2819c0/open-exp-code/open-exp-core-impl/src/main/java/cn/think/in/java/open/exp/core/impl/ExpAppContextImpl.java#L49-L51

https://github.com/stateIs0/exp/blob/7cdba8341afd106a5068c5e54043b76dbc2819c0/spring-adapter/open-exp-adapter-springboot-common-starter/src/main/java/open/exp/adapter/springboot/common/starter/ObjectStoreSpringboot.java#L65


as the above code, the **postInit(pluginId, classes)**  is ahead of **PluginLifeCycleHookManager.addHook(pluginId)** , which  
result in when invoke postInit, the PluginLifeCycleHook is not ready,  so we should fix it.

I use a simple way to fix it, which maybe not the elegant style, If have more elegant style, we should use it

also add some use sample with **UserPluginLifeCycleHook**

**Checklist**
 
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible