### PR TITLE
fixed:解决mac或者linux系统下，当exp-plugins插件目录有系统的隐藏文件，导致加载报错的问题。

### DIFF
--- a/open-exp-code/open-exp-core-impl/src/main/java/cn/think/in/java/open/exp/core/impl/Bootstrap.java
+++ b/open-exp-code/open-exp-core-impl/src/main/java/cn/think/in/java/open/exp/core/impl/Bootstrap.java
@@ -59,9 +59,12 @@ public class Bootstrap {
                 if (!file.exists()) {
                     continue;
                 }
-                log.info("准备安装插件, 压缩包路径: " + file.getAbsolutePath());
-                Plugin plugin = expAppContext.load(file);
-                tmp.add(plugin.getPluginId());
+                //不加载文件夹里面的隐藏文件。
+                if(!file.isHidden()) {
+                    log.info("准备安装插件, 压缩包路径: " + file.getAbsolutePath());
+                    Plugin plugin = expAppContext.load(file);
+                    tmp.add(plugin.getPluginId());
+                }
             } catch (Exception e) {
                 log.error(e.getMessage() + " ---->>>> " + file.getAbsolutePath(), e);
                 throw e;


### PR DESCRIPTION
fixed:解决mac或者linux系统下，当exp-plugins插件目录有系统的隐藏文件，导致加载报错的问题。
![WX20231227-211628@2x](https://github.com/stateIs0/exp/assets/39484553/2ae34b22-1f27-419c-adb6-26324bb61779)
